### PR TITLE
Fixes long press handler

### DIFF
--- a/Source/model/scene/Node.swift
+++ b/Source/model/scene/Node.swift
@@ -251,9 +251,8 @@ open class Node: Drawable {
     func handleLongTap( _ event: TapEvent, touchBegan: Bool ) {
         isLongTapInProgress = touchBegan
         if touchBegan {
-            return
+            longTapHandlers.forEach { handler in handler.handle(event) }
         }
-        longTapHandlers.forEach { handler in handler.handle(event) }
     }
 
     func handlePan( _ event: PanEvent ) {


### PR DESCRIPTION
Macaw's original implementation for long press feature triggers handlers when touch ends or moves.
As result we receive long press event only when user releases his finger or significantly moves.
We need to receive handler immediately after user holds his finger for 0.5 seconds.

For this purpose we need to trigger handler on `.begin` event: https://developer.apple.com/documentation/uikit/uilongpressgesturerecognizer